### PR TITLE
Add MAC address set function

### DIFF
--- a/platform/mbed_interface.c
+++ b/platform/mbed_interface.c
@@ -84,9 +84,13 @@ WEAK int mbed_uid(char *uid) {
 static uint8_t manual_mac_address_set = 0;
 static char manual_mac_address[6];
 
-void mbed_set_mac_address(const char *mac) {
+void mbed_set_mac_address(const char *mac, uint8_t coerce_mac_control_bits) {
     memcpy(manual_mac_address, mac, 6);
     manual_mac_address_set = 1;
+    if(coerce_mac_control_bits) {
+        manual_mac_address[0] |= 0x02; // force bit 1 to a "1" = "Locally Administered"
+        manual_mac_address[0] &= 0xFE; // force bit 0 to a "0" = Unicast
+    }
 }
 
 WEAK void mbed_mac_address(char *mac) {

--- a/platform/mbed_interface.c
+++ b/platform/mbed_interface.c
@@ -82,12 +82,11 @@ WEAK int mbed_uid(char *uid) {
 #endif
 
 static uint8_t manual_mac_address_set = 0;
-static char manual_mac_address[6] = {0,1,2,3,4,5};
+static char manual_mac_address[6];
 
 void mbed_set_mac_address(const char *mac) {
     memcpy(manual_mac_address, mac, 6);
     manual_mac_address_set = 1;
-    printf("%c\r\n", manual_mac_address[0]);
 }
 
 WEAK void mbed_mac_address(char *mac) {
@@ -111,9 +110,7 @@ WEAK void mbed_mac_address(char *mac) {
     } else {  // else return a default MAC
 #endif
     if(manual_mac_address_set) {
-        printf("beepboop\r\n");
         memcpy(mac, manual_mac_address, 6);
-        printf("%c\r\n", mac[0]);
     } else {
         mac[0] = 0x00;
         mac[1] = 0x02;

--- a/platform/mbed_interface.c
+++ b/platform/mbed_interface.c
@@ -81,6 +81,15 @@ WEAK int mbed_uid(char *uid) {
 }
 #endif
 
+static uint8_t manual_mac_address_set = 0;
+static char manual_mac_address[6] = {0,1,2,3,4,5};
+
+void mbed_set_mac_address(const char *mac) {
+    memcpy(manual_mac_address, mac, 6);
+    manual_mac_address_set = 1;
+    printf("%c\r\n", manual_mac_address[0]);
+}
+
 WEAK void mbed_mac_address(char *mac) {
 #if DEVICE_SEMIHOST
     char uid[DEVICE_ID_LENGTH + 1];
@@ -101,12 +110,18 @@ WEAK void mbed_mac_address(char *mac) {
         mac[0] &= ~0x01;    // reset the IG bit in the address; see IEE 802.3-2002, Section 3.2.3(b)
     } else {  // else return a default MAC
 #endif
+    if(manual_mac_address_set) {
+        printf("beepboop\r\n");
+        memcpy(mac, manual_mac_address, 6);
+        printf("%c\r\n", mac[0]);
+    } else {
         mac[0] = 0x00;
         mac[1] = 0x02;
         mac[2] = 0xF7;
         mac[3] = 0xF0;
         mac[4] = 0x00;
         mac[5] = 0x00;
+    }
 #if DEVICE_SEMIHOST
     }
 #endif

--- a/platform/mbed_interface.h
+++ b/platform/mbed_interface.h
@@ -104,8 +104,11 @@ int mbed_interface_uid(char *uid);
  *  mbed_mac_address() will readback this configured value
  *
  *  @param mac A 6-byte array containing the desired MAC address to be set
+ *  @param coerce_mac_control_bits An 8-bit int that is used as a boolean flag to either coerce
+ *         the provided MAC address to be Locally Administered and Unicast or to use the
+ *         provided MAC address unmodified
  */
-void mbed_set_mac_address(const char *mac);
+void mbed_set_mac_address(const char *mac, uint8_t coerce_mac_control_bits);
 
 /** This returns a unique 6-byte MAC address, based on the interface UID
  * If the interface is not present, it returns a default fixed MAC address (00:02:F7:F0:00:00)

--- a/platform/mbed_interface.h
+++ b/platform/mbed_interface.h
@@ -108,6 +108,9 @@ int mbed_interface_uid(char *uid);
  */
 void mbed_mac_address(char *mac);
 
+//TODO:DOC
+void mbed_set_mac_address(const char *mac);
+
 /** Cause the mbed to flash the BLOD (Blue LEDs Of Death) sequence
  */
 void mbed_die(void);

--- a/platform/mbed_interface.h
+++ b/platform/mbed_interface.h
@@ -98,6 +98,15 @@ int mbed_interface_uid(char *uid);
 
 #endif
 
+/** This provides a generic function to set a unique 6-byte MAC address based on the passed
+ *  parameter character array. Provides no MAC address validity checking
+ *  
+ *  mbed_mac_address() will readback this configured value
+ *
+ *  @param mac A 6-byte array containing the desired MAC address to be set
+ */
+void mbed_set_mac_address(const char *mac);
+
 /** This returns a unique 6-byte MAC address, based on the interface UID
  * If the interface is not present, it returns a default fixed MAC address (00:02:F7:F0:00:00)
  *
@@ -107,9 +116,6 @@ int mbed_interface_uid(char *uid);
  *  @param mac A 6-byte array to write the MAC address
  */
 void mbed_mac_address(char *mac);
-
-//TODO:DOC
-void mbed_set_mac_address(const char *mac);
 
 /** Cause the mbed to flash the BLOD (Blue LEDs Of Death) sequence
  */


### PR DESCRIPTION
Tested on K64F, NUCLEO, and the Peach.

Couldn't set a default argument in C unfortunately. Didn't want to mess around with adding boolean support (failed NUCLEO builds) so used uint8_t instead. 

_______________________________________________________________________________

Test program used:

```
#include "mbed.h"

 DigitalOut led1(LED2);
 DigitalOut led2(LED3);
 extern "C" void mbed_set_mac_address(const char *mac);
 extern "C" void mbed_mac_address(char *mac);

 int main() {
     char mac[6];
     char mac2[6];
     mbed_mac_address(mac);
     for(int i=0; i<6; ++i) {
         printf("%02X ", mac[i]);
     }
     printf("\r\n");

     for(int i=0; i<3; ++i) {
         uint8_t temp;
         temp = mac[i];
         mac[i] = mac[5-i];
         mac[5-i] = temp;
     }

     mbed_set_mac_address(mac, 1 /*coerce MAC address control bits to Locally Administrated and Unicast*/ );
     mbed_mac_address(mac2);
     for(int i=0; i<6; ++i) {
         printf("%02X ", mac2[i]);
     }
     printf("\r\n");

     while (true) {}
}```